### PR TITLE
add check to the semaphore destructor to avoid segmentation fault

### DIFF
--- a/sources/os/CountingSemaphore.cpp
+++ b/sources/os/CountingSemaphore.cpp
@@ -14,13 +14,13 @@ CountingSemaphore::CountingSemaphore(uint32_t maximalCount,
                                               initalCount))
 {}
 
-CountingSemaphore::CountingSemaphore(CountingSemaphore&& rhs) :
+CountingSemaphore::CountingSemaphore(CountingSemaphore && rhs) :
     mSemaphoreHandle(rhs.mSemaphoreHandle)
 {
     rhs.mSemaphoreHandle = nullptr;
 }
 
-CountingSemaphore& CountingSemaphore::operator=(CountingSemaphore&& rhs)
+CountingSemaphore& CountingSemaphore::operator=(CountingSemaphore && rhs)
 {
     mSemaphoreHandle = rhs.mSemaphoreHandle;
     rhs.mSemaphoreHandle = nullptr;
@@ -29,7 +29,9 @@ CountingSemaphore& CountingSemaphore::operator=(CountingSemaphore&& rhs)
 
 CountingSemaphore::~CountingSemaphore(void)
 {
-    vSemaphoreDelete(mSemaphoreHandle);
+    if (*this) {
+        vSemaphoreDelete(mSemaphoreHandle);
+    }
 }
 
 bool CountingSemaphore::take(uint32_t ticksToWait) const

--- a/sources/os/Mutex.cpp
+++ b/sources/os/Mutex.cpp
@@ -11,13 +11,13 @@ Mutex::Mutex(void) :
     mMutexHandle(xSemaphoreCreateMutex())
 {}
 
-Mutex::Mutex(Mutex&& rhs) :
+Mutex::Mutex(Mutex && rhs) :
     mMutexHandle(rhs.mMutexHandle)
 {
     rhs.mMutexHandle = nullptr;
 }
 
-Mutex& Mutex::operator=(Mutex&& rhs)
+Mutex& Mutex::operator=(Mutex && rhs)
 {
     mMutexHandle = rhs.mMutexHandle;
     rhs.mMutexHandle = nullptr;
@@ -26,7 +26,9 @@ Mutex& Mutex::operator=(Mutex&& rhs)
 
 Mutex::~Mutex(void)
 {
-    vSemaphoreDelete(mMutexHandle);
+    if (*this) {
+        vSemaphoreDelete(mMutexHandle);
+    }
 }
 
 bool Mutex::take(uint32_t ticksToWait) const

--- a/sources/os/RecursiveMutex.cpp
+++ b/sources/os/RecursiveMutex.cpp
@@ -11,13 +11,13 @@ RecursiveMutex::RecursiveMutex(void) :
     mMutexHandle(xSemaphoreCreateRecursiveMutex())
 {}
 
-RecursiveMutex::RecursiveMutex(RecursiveMutex&& rhs) :
+RecursiveMutex::RecursiveMutex(RecursiveMutex && rhs) :
     mMutexHandle(rhs.mMutexHandle)
 {
     rhs.mMutexHandle = nullptr;
 }
 
-RecursiveMutex& RecursiveMutex::operator=(RecursiveMutex&& rhs)
+RecursiveMutex& RecursiveMutex::operator=(RecursiveMutex && rhs)
 {
     mMutexHandle = rhs.mMutexHandle;
     rhs.mMutexHandle = nullptr;
@@ -26,7 +26,9 @@ RecursiveMutex& RecursiveMutex::operator=(RecursiveMutex&& rhs)
 
 RecursiveMutex::~RecursiveMutex(void)
 {
-    vSemaphoreDelete(mMutexHandle);
+    if (*this) {
+        vSemaphoreDelete(mMutexHandle);
+    }
 }
 
 bool RecursiveMutex::take(const uint32_t ticksToWait) const

--- a/sources/os/Semaphore.cpp
+++ b/sources/os/Semaphore.cpp
@@ -12,13 +12,13 @@ Semaphore::Semaphore(void) :
     mSemaphoreHandle(xSemaphoreCreateBinary())
 {}
 
-Semaphore::Semaphore(Semaphore&& rhs) :
+Semaphore::Semaphore(Semaphore && rhs) :
     mSemaphoreHandle(rhs.mSemaphoreHandle)
 {
     rhs.mSemaphoreHandle = nullptr;
 }
 
-Semaphore& Semaphore::operator=(Semaphore&& rhs)
+Semaphore& Semaphore::operator=(Semaphore && rhs)
 {
     mSemaphoreHandle = rhs.mSemaphoreHandle;
     rhs.mSemaphoreHandle = nullptr;
@@ -27,7 +27,9 @@ Semaphore& Semaphore::operator=(Semaphore&& rhs)
 
 Semaphore::~Semaphore(void)
 {
-    vSemaphoreDelete(mSemaphoreHandle);
+    if (*this) {
+        vSemaphoreDelete(mSemaphoreHandle);
+    }
 }
 
 bool Semaphore::take(const uint32_t ticksToWait) const


### PR DESCRIPTION
for semaphores with invalid handles. 

A semaphore can invalidate its handle, with the std::move operation, that was explicitly defined.