### PR TITLE
Communication

### DIFF
--- a/project/Makefile.in
+++ b/project/Makefile.in
@@ -76,7 +76,7 @@ check:
 	@@CPPCHECKER@ --enable=all --inconclusive -I ./config/ -I ../sources/hal/ -I ../sources/dev/ -I ../sources/app/ -I ../sources/utility/ -I ../sources/interface/ -I ../sources/os/ -I ../libraries/STM32F30x_StdPeriph_Driver/inc/ --std=posix --quiet .
 
 ENDINGS=c h cpp
-CODE_DIRS=../sources config ../libraries/VESC ../libraries/Filters-master
+CODE_DIRS=../sources config ./
 filelist:
 	@rm -f $@.txt
 	@$(foreach END, ${ENDINGS}, $(foreach DIR, ${CODE_DIRS}, find ./$(DIR) -name "*.$(END)" >> $@.txt;))

--- a/project/Makefile.test
+++ b/project/Makefile.test
@@ -62,6 +62,14 @@ ${BINDIR}/PIDController_ut.bin: ${OBJDIR}/PIDController_ut.o
 ${BINDIR}/DataTransferObject_ut.bin: DEFINES +=-DUNITTEST
 ${BINDIR}/DataTransferObject_ut.bin: ${OBJDIR}/DataTransferObject_ut.o
 
+##################################### Communication ##########################################
+
+${BINDIR}/Communication_ut.bin: DEFINES +=-DUNITTEST
+${BINDIR}/Communication_ut.bin: DEFINES +=-pthread
+${BINDIR}/Communication_ut.bin: DEFINES +=-DCOM_INTERFACE=MSCOM_IF
+${BINDIR}/Communication_ut.bin: ${OBJDIR}/Communication_ut.o
+${BINDIR}/Communication_ut.bin: ${OBJDIR}/DeepSleepInterface.o
+
 ################################################################################
 
 test: clean-all ${BINDIR} ${OBJDIR} test_binarys
@@ -74,6 +82,7 @@ TESTS+=${BINDIR}/BatteryObserver_ut.bin
 TESTS+=${BINDIR}/TemperatureSensor_ut.bin	
 TESTS+=${BINDIR}/PIDController_ut.bin
 TESTS+=${BINDIR}/DataTransferObject_ut.bin
+TESTS+=${BINDIR}/Communication_ut.bin
 
 test_binarys: ${TESTS}  
 	@echo "-------------------------------------------------------------"

--- a/project/Makefile.test
+++ b/project/Makefile.test
@@ -3,6 +3,7 @@ IPATH+=${ROOT}/sources/config
 IPATH+=${ROOT}/sources/app
 IPATH+=${ROOT}/sources/os
 IPATH+=${ROOT}/sources/dev
+IPATH+=${ROOT}/sources/com
 IPATH+=${ROOT}/sources/interface
 IPATH+=${ROOT}/sources/utility
 IPATH+=${ROOT}/sources/hal_stm32f30x
@@ -22,6 +23,7 @@ VPATH+=${ROOT}/sources
 VPATH+=${ROOT}/sources/dev
 VPATH+=${ROOT}/sources/os
 VPATH+=${ROOT}/sources/app
+VPATH+=${ROOT}/sources/com
 VPATH+=${ROOT}/sources/interface
 VPATH+=${ROOT}/sources/hal_stm32f30x
 
@@ -55,6 +57,11 @@ ${BINDIR}/PIDController_ut.bin: DEFINES+=-DUNITTEST
 ${BINDIR}/PIDController_ut.bin: ${OBJDIR}/PIDController.o
 ${BINDIR}/PIDController_ut.bin: ${OBJDIR}/PIDController_ut.o
 
+################################## DataTransferObject ########################################
+
+${BINDIR}/DataTransferObject_ut.bin: DEFINES +=-DUNITTEST
+${BINDIR}/DataTransferObject_ut.bin: ${OBJDIR}/DataTransferObject_ut.o
+
 ################################################################################
 
 test: clean-all ${BINDIR} ${OBJDIR} test_binarys
@@ -66,6 +73,7 @@ TESTS=${BINDIR}/DebugInterface_ut.bin
 TESTS+=${BINDIR}/BatteryObserver_ut.bin
 TESTS+=${BINDIR}/TemperatureSensor_ut.bin	
 TESTS+=${BINDIR}/PIDController_ut.bin
+TESTS+=${BINDIR}/DataTransferObject_ut.bin
 
 test_binarys: ${TESTS}  
 	@echo "-------------------------------------------------------------"

--- a/project/config/UsartWithDma_config.h
+++ b/project/config/UsartWithDma_config.h
@@ -2,14 +2,20 @@
 /*
  * Copyright (c) 2014-2018 Nils Weiss
  */
+#ifndef SOURCES_PMD_USARTWITHDMA_CONFIG_DESCRIPTION_H_
+#define SOURCES_PMD_USARTWITHDMA_CONFIG_DESCRIPTION_H_
 
+static constexpr const uint8_t NUMBER_OF_INSTANCES = 1;
+
+#else
 #ifndef SOURCES_PMD_USARTWITHDMA_CONFIG_CONTAINER_H_
 #define SOURCES_PMD_USARTWITHDMA_CONFIG_CONTAINER_H_
 
-static constexpr const std::array<const UsartWithDma, 1> Container =
+static constexpr const std::array<const UsartWithDma, UsartWithDma::NUMBER_OF_INSTANCES> Container =
 { {
       UsartWithDma(Factory<Usart>::get<Usart::MSCOM_IF>(), USART_DMAReq_Rx | USART_DMAReq_Tx,
                    &Factory<Dma>::get<Dma::USART1_TX>(), &Factory<Dma>::get<Dma::USART1_RX>())
   } };
 
-#endif /* SOURCES_PMD_USART_CONFIG_CONTAINER_H_ */
+#endif // SOURCES_PMD_USART_CONFIG_CONTAINER_H_
+#endif // SOURCES_PMD_USARTWITHDMA_CONFIG_DESCRIPTION_H_

--- a/sources/app/Communication_ut.cpp
+++ b/sources/app/Communication_ut.cpp
@@ -149,9 +149,7 @@ int ut_CrcError(void)
                                                                    txDto,
                                                                    [&](auto error)
         {
-                                                                   if (error ==
-                                                                       decltype(masterCom) ::ErrorCode::CRC_ERROR)
-                                                                   {
+                                                                   if (error == com::ErrorCode::CRC_ERROR) {
                                                                        crcError = true;
                                                                    }
         });

--- a/sources/app/Communication_ut.cpp
+++ b/sources/app/Communication_ut.cpp
@@ -169,12 +169,16 @@ int ut_CrcError(void)
     slaveCom.triggerRxTaskExecution();
 
     CHECK(crcError == false);
+    CHECK(masterCom.isConnected() == true);
+    CHECK(slaveCom.isConnected() == true);
 
     g_crc = 0x11;
 
     masterCom.triggerRxTaskExecution();
 
     CHECK(crcError == true);
+    CHECK(masterCom.isConnected() == false);
+    CHECK(slaveCom.isConnected() == true);
 
     TestCaseEnd();
 }

--- a/sources/com/DataTransferObject_ut.cpp
+++ b/sources/com/DataTransferObject_ut.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 /*
  * Copyright (c) 2014-2018 Nils Weiss
+ * Modified 2019 by Henning Mende
  */
 
 #include <cmath>
@@ -15,7 +16,12 @@
 
 //--------------------------BUFFERS--------------------------
 uint32_t g_currentTickCount;
+
+#ifdef CRC_32BIT
+uint32_t g_crc;
+#else
 uint8_t g_crc;
+#endif // CRC_32BIT
 
 //--------------------------MOCKING--------------------------
 constexpr const std::array<const hal::Crc, hal::Crc::__ENUM__SIZE> hal::Factory<hal::Crc>::Container;
@@ -29,10 +35,17 @@ uint32_t os::Task::getTickCount(void)
     return g_currentTickCount;
 }
 
+#ifdef CRC_32BIT
+uint32_t hal::Crc::getCrc(uint8_t const* const data, const size_t length) const
+{
+    return g_crc;
+}
+#else
 uint8_t hal::Crc::getCrc(uint8_t const* const data, const size_t length) const
 {
     return g_crc;
 }
+#endif // CRC_32BIT
 
 //-------------------------TESTCASES-------------------------
 
@@ -49,7 +62,7 @@ int ut_length(void)
 
     com::DataTransferObject<uint8_t, uint32_t, uint16_t> dto(c, a, b);
 
-    const size_t length = sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint8_t);
+    const size_t length = sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint8_t) + sizeof(uint32_t) + sizeof(g_crc);
 
     CHECK(dto.length() == length);
 

--- a/sources/hal_stm32f30x/UsartWithDma.h
+++ b/sources/hal_stm32f30x/UsartWithDma.h
@@ -53,6 +53,9 @@ struct UsartWithDma {
     const Usart& mUsart;
 
 private:
+
+#include "UsartWithDma_config.h"
+
     constexpr UsartWithDma(const Usart&     usartInterface,
                            const uint16_t&  dmaCmd = 0,
                            Dma const* const txDma = nullptr,

--- a/sources/hal_stm32f4xx/UsartWithDma.h
+++ b/sources/hal_stm32f4xx/UsartWithDma.h
@@ -72,6 +72,11 @@ struct UsartWithDma {
     bool isReadyToReceive(void) const;
     bool isReadyToSend(void) const;
 
+    /// Does nothing, just for legacy compatibility.
+    constexpr inline void enableReceiveTimeout(const size_t bitsUntilTimeout) const {}
+    /// Does nothing, just for legacy compatibility.
+    constexpr inline void disableReceiveTimeout(void) const {}
+
     const Usart& mUsart;
 
 private:

--- a/sources/utility/returnTypeDeduction.h
+++ b/sources/utility/returnTypeDeduction.h
@@ -1,0 +1,97 @@
+/// @file returnTypeDeduction.h
+/// @brief Helper functions to deduct the return type at compile time.
+/// @author Henning Mende (henning@my-urmo.com)
+/// @date   Sep 12, 2019
+/// @copyright UrmO GmbH
+///
+/// This program is free software: you can redistribute it and/or modify it under the terms
+/// of the GNU General Public License as published by the Free Software Foundation, either
+/// version 3 of the License, or (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+/// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+/// See the GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License along with this program.
+/// If not, see <https://www.gnu.org/licenses/>.
+///
+#ifndef SOURCES_UTILITY_RETURNTYPEDEDUCTION_H_
+#define SOURCES_UTILITY_RETURNTYPEDEDUCTION_H_
+
+namespace utility
+{
+/// @brief Helper to determine the return type of a function.
+///
+/// This can be used to determine the return type of overloaded or templated functions at
+/// compile time, even if the functions are not `constexpr`.
+///
+/// Usage:
+/// @code
+/// int foo(float a);
+/// float foo(int a);
+/// decltype(getReturnType<float>(foo)) b = 3;
+/// @endcode
+///
+/// In this example b is int.
+///
+/// @tparam R Return type (evaluated automatically).
+/// @tparam A Argument types for the target function (for overloaded functions).
+/// @param * Function with @a A parameters.
+/// @return Type of the return value of @a *.
+template<typename R, typename ... A>
+R getReturnType(R (*)(A ...));
+
+/// @brief Helper to determine the return type of a method.
+///
+/// This can be used to determine the return type of overloaded or templated methods at compile
+/// time, even if the methods are not `constexpr`.
+///
+/// Usage:
+/// @code
+/// struct Foo {
+///     int foo(float a);
+///     float foo(int a);
+///    } fooInstance;
+///    decltype(utility::getReturnType<float>(& Foo::foo)) b = 3;
+///    decltype(utility::getReturnType<float>(& decltype(fooInstance)::foo)) c = 3;
+/// @endcode
+///
+/// In this example b and c are int.
+///
+/// @tparam M Matching version of the overloaded method (evaluated by template parameter @a A).
+/// @tparam C Class name (evaluated by argument).
+/// @tparam R Return type (evaluated automatically).
+/// @tparam A Argument types for the target method (for overloaded methods).
+/// @param * Method with @a A parameters.
+/// @return Type of the return value of @a *.
+template<typename M, typename C, typename R, typename ... A>
+R getReturnType(R (C::*)(M, A ...));
+
+/// @brief Helper to determine the return type of a const method.
+///
+/// This can be used to determine the return type of overloaded or templated methods at compile
+/// time, even if the methods are not `constexpr`.
+///
+/// Usage:
+/// @code
+/// struct Foo {
+///     int foo(float a) const;
+///     float foo(int a) const;
+///    } fooInstance;
+///    decltype(utility::getReturnType<float>(& Foo::foo)) b = 3;
+///    decltype(utility::getReturnType<float>(& decltype(fooInstance)::foo)) c = 3;
+/// @endcode
+///
+/// In this example b and c are int.
+///
+/// @tparam V Matching version of the overloaded method (evaluated by template parameter @a A).
+/// @tparam C Class name (evaluated by argument).
+/// @tparam R Return type (evaluated automatically).
+/// @tparam A Argument types for the target method (for overloaded methods).
+/// @param * Method with A parameters.
+/// @return Type of the return value of @a *.
+template<typename V, typename C, typename R, typename ... A>
+R getReturnType(R (C::*)(V, A ...) const);
+} // namespace utility
+
+#endif // SOURCES_UTILITY_RETURNTYPEDEDUCTION_H_


### PR DESCRIPTION
Content:
- Correction in the data transfer objects to use them also with 32 Bit CRCs.
- Clearing of the receive buffer for controllers without hardware timeout.
- Indicator for an established connection.

Implications:
- Legacy code for projects I have never worked on was adapted.
- This branch is based on the both branches from the other pull requests #57 and #58. So merging this introduces the changes from these branches, too. If you want to merge all three anyway, then just merging this is sufficient.
