### PR TITLE
Os layer test mock

### DIFF
--- a/project/Makefile.in
+++ b/project/Makefile.in
@@ -76,7 +76,7 @@ check:
 	@@CPPCHECKER@ --enable=all --inconclusive -I ./config/ -I ../sources/hal/ -I ../sources/dev/ -I ../sources/app/ -I ../sources/utility/ -I ../sources/interface/ -I ../sources/os/ -I ../libraries/STM32F30x_StdPeriph_Driver/inc/ --std=posix --quiet .
 
 ENDINGS=c h cpp
-CODE_DIRS=../sources config ../libraries/VESC ../libraries/Filters-master
+CODE_DIRS=../sources config ./
 filelist:
 	@rm -f $@.txt
 	@$(foreach END, ${ENDINGS}, $(foreach DIR, ${CODE_DIRS}, find ./$(DIR) -name "*.$(END)" >> $@.txt;))

--- a/project/Makefile.test
+++ b/project/Makefile.test
@@ -62,6 +62,14 @@ ${BINDIR}/PIDController_ut.bin: ${OBJDIR}/PIDController_ut.o
 ${BINDIR}/DataTransferObject_ut.bin: DEFINES +=-DUNITTEST
 ${BINDIR}/DataTransferObject_ut.bin: ${OBJDIR}/DataTransferObject_ut.o
 
+##################################### Communication ##########################################
+
+${BINDIR}/Communication_ut.bin: DEFINES +=-DUNITTEST
+${BINDIR}/Communication_ut.bin: DEFINES +=-pthread
+${BINDIR}/Communication_ut.bin: DEFINES +=-DCOM_INTERFACE=MSCOM_IF
+${BINDIR}/Communication_ut.bin: ${OBJDIR}/Communication_ut.o
+${BINDIR}/Communication_ut.bin: ${OBJDIR}/DeepSleepInterface.o
+
 ################################################################################
 
 test: clean-all ${BINDIR} ${OBJDIR} test_binarys
@@ -74,6 +82,7 @@ TESTS+=${BINDIR}/BatteryObserver_ut.bin
 TESTS+=${BINDIR}/TemperatureSensor_ut.bin	
 TESTS+=${BINDIR}/PIDController_ut.bin
 TESTS+=${BINDIR}/DataTransferObject_ut.bin
+TESTS+=${BINDIR}/Communication_ut.bin
 
 test_binarys: ${TESTS}  
 	@echo "-------------------------------------------------------------"

--- a/project/Makefile.test
+++ b/project/Makefile.test
@@ -3,6 +3,7 @@ IPATH+=${ROOT}/sources/config
 IPATH+=${ROOT}/sources/app
 IPATH+=${ROOT}/sources/os
 IPATH+=${ROOT}/sources/dev
+IPATH+=${ROOT}/sources/com
 IPATH+=${ROOT}/sources/interface
 IPATH+=${ROOT}/sources/utility
 IPATH+=${ROOT}/sources/hal_stm32f30x
@@ -22,6 +23,7 @@ VPATH+=${ROOT}/sources
 VPATH+=${ROOT}/sources/dev
 VPATH+=${ROOT}/sources/os
 VPATH+=${ROOT}/sources/app
+VPATH+=${ROOT}/sources/com
 VPATH+=${ROOT}/sources/interface
 VPATH+=${ROOT}/sources/hal_stm32f30x
 
@@ -55,6 +57,11 @@ ${BINDIR}/PIDController_ut.bin: DEFINES+=-DUNITTEST
 ${BINDIR}/PIDController_ut.bin: ${OBJDIR}/PIDController.o
 ${BINDIR}/PIDController_ut.bin: ${OBJDIR}/PIDController_ut.o
 
+################################## DataTransferObject ########################################
+
+${BINDIR}/DataTransferObject_ut.bin: DEFINES +=-DUNITTEST
+${BINDIR}/DataTransferObject_ut.bin: ${OBJDIR}/DataTransferObject_ut.o
+
 ################################################################################
 
 test: clean-all ${BINDIR} ${OBJDIR} test_binarys
@@ -66,6 +73,7 @@ TESTS=${BINDIR}/DebugInterface_ut.bin
 TESTS+=${BINDIR}/BatteryObserver_ut.bin
 TESTS+=${BINDIR}/TemperatureSensor_ut.bin	
 TESTS+=${BINDIR}/PIDController_ut.bin
+TESTS+=${BINDIR}/DataTransferObject_ut.bin
 
 test_binarys: ${TESTS}  
 	@echo "-------------------------------------------------------------"

--- a/project/config/UsartWithDma_config.h
+++ b/project/config/UsartWithDma_config.h
@@ -2,14 +2,20 @@
 /*
  * Copyright (c) 2014-2018 Nils Weiss
  */
+#ifndef SOURCES_PMD_USARTWITHDMA_CONFIG_DESCRIPTION_H_
+#define SOURCES_PMD_USARTWITHDMA_CONFIG_DESCRIPTION_H_
 
+static constexpr const uint8_t NUMBER_OF_INSTANCES = 1;
+
+#else
 #ifndef SOURCES_PMD_USARTWITHDMA_CONFIG_CONTAINER_H_
 #define SOURCES_PMD_USARTWITHDMA_CONFIG_CONTAINER_H_
 
-static constexpr const std::array<const UsartWithDma, 1> Container =
+static constexpr const std::array<const UsartWithDma, UsartWithDma::NUMBER_OF_INSTANCES> Container =
 { {
       UsartWithDma(Factory<Usart>::get<Usart::MSCOM_IF>(), USART_DMAReq_Rx | USART_DMAReq_Tx,
                    &Factory<Dma>::get<Dma::USART1_TX>(), &Factory<Dma>::get<Dma::USART1_RX>())
   } };
 
-#endif /* SOURCES_PMD_USART_CONFIG_CONTAINER_H_ */
+#endif // SOURCES_PMD_USART_CONFIG_CONTAINER_H_
+#endif // SOURCES_PMD_USARTWITHDMA_CONFIG_DESCRIPTION_H_

--- a/project_stm32f4_discovery/Makefile.test
+++ b/project_stm32f4_discovery/Makefile.test
@@ -39,6 +39,15 @@ ${BINDIR}/PIDController_ut.bin: DEFINES+=-DUNITTEST
 ${BINDIR}/PIDController_ut.bin: ${OBJDIR}/PIDController.o
 ${BINDIR}/PIDController_ut.bin: ${OBJDIR}/PIDController_ut.o
 
+##################################### OsTestMockup ###########################################
+
+${BINDIR}/OsTestMockup_ut.bin: DEFINES +=-DUNITTEST
+${BINDIR}/OsTestMockup_ut.bin:  DEFINES +=-pthread
+${BINDIR}/OsTestMockup_ut.bin: ${OBJDIR}/OsTestMockup_ut.o
+${BINDIR}/OsTestMockup_ut.bin: ${OBJDIR}/MutexTestMockup.o
+${BINDIR}/OsTestMockup_ut.bin: ${OBJDIR}/SemaphoreTestMockup.o
+${BINDIR}/OsTestMockup_ut.bin: ${OBJDIR}/TaskTestMockup.o
+
 ################################################################################
 
 test: clean-all ${BINDIR} ${OBJDIR} test_binarys
@@ -48,6 +57,7 @@ test: clean-all ${BINDIR} ${OBJDIR} test_binarys
 
 TESTS=${BINDIR}/DebugInterface_ut.bin
 TESTS+=${BINDIR}/PIDController_ut.bin
+TESTS+=${BINDIR}/OsTestMockup_ut.bin
 
 test_binarys: ${TESTS}  
 	@echo "-------------------------------------------------------------"

--- a/project_stm32f4_discovery/Makefile.test
+++ b/project_stm32f4_discovery/Makefile.test
@@ -47,6 +47,7 @@ ${BINDIR}/OsTestMockup_ut.bin: ${OBJDIR}/OsTestMockup_ut.o
 ${BINDIR}/OsTestMockup_ut.bin: ${OBJDIR}/MutexTestMockup.o
 ${BINDIR}/OsTestMockup_ut.bin: ${OBJDIR}/SemaphoreTestMockup.o
 ${BINDIR}/OsTestMockup_ut.bin: ${OBJDIR}/TaskTestMockup.o
+${BINDIR}/OsTestMockup_ut.bin: ${OBJDIR}/TaskInterruptableTestMockup.o
 
 ################################################################################
 

--- a/sources/app/Communication_ut.cpp
+++ b/sources/app/Communication_ut.cpp
@@ -149,9 +149,7 @@ int ut_CrcError(void)
                                                                    txDto,
                                                                    [&](auto error)
         {
-                                                                   if (error ==
-                                                                       decltype(masterCom) ::ErrorCode::CRC_ERROR)
-                                                                   {
+                                                                   if (error == com::ErrorCode::CRC_ERROR) {
                                                                        crcError = true;
                                                                    }
         });

--- a/sources/app/Communication_ut.cpp
+++ b/sources/app/Communication_ut.cpp
@@ -169,12 +169,16 @@ int ut_CrcError(void)
     slaveCom.triggerRxTaskExecution();
 
     CHECK(crcError == false);
+    CHECK(masterCom.isConnected() == true);
+    CHECK(slaveCom.isConnected() == true);
 
     g_crc = 0x11;
 
     masterCom.triggerRxTaskExecution();
 
     CHECK(crcError == true);
+    CHECK(masterCom.isConnected() == false);
+    CHECK(slaveCom.isConnected() == true);
 
     TestCaseEnd();
 }

--- a/sources/com/DataTransferObject_ut.cpp
+++ b/sources/com/DataTransferObject_ut.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 /*
  * Copyright (c) 2014-2018 Nils Weiss
+ * Modified 2019 by Henning Mende
  */
 
 #include <cmath>
@@ -15,7 +16,12 @@
 
 //--------------------------BUFFERS--------------------------
 uint32_t g_currentTickCount;
+
+#ifdef CRC_32BIT
+uint32_t g_crc;
+#else
 uint8_t g_crc;
+#endif // CRC_32BIT
 
 //--------------------------MOCKING--------------------------
 constexpr const std::array<const hal::Crc, hal::Crc::__ENUM__SIZE> hal::Factory<hal::Crc>::Container;
@@ -29,10 +35,17 @@ uint32_t os::Task::getTickCount(void)
     return g_currentTickCount;
 }
 
+#ifdef CRC_32BIT
+uint32_t hal::Crc::getCrc(uint8_t const* const data, const size_t length) const
+{
+    return g_crc;
+}
+#else
 uint8_t hal::Crc::getCrc(uint8_t const* const data, const size_t length) const
 {
     return g_crc;
 }
+#endif // CRC_32BIT
 
 //-------------------------TESTCASES-------------------------
 
@@ -49,7 +62,7 @@ int ut_length(void)
 
     com::DataTransferObject<uint8_t, uint32_t, uint16_t> dto(c, a, b);
 
-    const size_t length = sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint8_t);
+    const size_t length = sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint8_t) + sizeof(uint32_t) + sizeof(g_crc);
 
     CHECK(dto.length() == length);
 

--- a/sources/hal_stm32f30x/UsartWithDma.h
+++ b/sources/hal_stm32f30x/UsartWithDma.h
@@ -53,6 +53,9 @@ struct UsartWithDma {
     const Usart& mUsart;
 
 private:
+
+#include "UsartWithDma_config.h"
+
     constexpr UsartWithDma(const Usart&     usartInterface,
                            const uint16_t&  dmaCmd = 0,
                            Dma const* const txDma = nullptr,

--- a/sources/hal_stm32f4xx/UsartWithDma.h
+++ b/sources/hal_stm32f4xx/UsartWithDma.h
@@ -72,6 +72,11 @@ struct UsartWithDma {
     bool isReadyToReceive(void) const;
     bool isReadyToSend(void) const;
 
+    /// Does nothing, just for legacy compatibility.
+    constexpr inline void enableReceiveTimeout(const size_t bitsUntilTimeout) const {}
+    /// Does nothing, just for legacy compatibility.
+    constexpr inline void disableReceiveTimeout(void) const {}
+
     const Usart& mUsart;
 
 private:

--- a/sources/os/MutexTestMockup.cpp
+++ b/sources/os/MutexTestMockup.cpp
@@ -1,0 +1,70 @@
+/// @file MutexTestMockup.cpp
+/// @brief Mockup for software tests of classes dependent on os::Mutex.
+/// @author Henning Mende (henning@my-urmo.com)
+/// @date   Nov 19, 2019
+/// @copyright UrmO GmbH
+///
+/// This program is free software: you can redistribute it and/or modify it under the terms
+/// of the GNU General Public License as published by the Free Software Foundation, either
+/// version 3 of the License, or (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+/// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+/// See the GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License along with this program.
+/// If not, see <https://www.gnu.org/licenses/>.
+#include "Mutex.h"
+#include <mutex>
+
+namespace os
+{
+Mutex::Mutex(void) :
+    mMutexHandle((SemaphoreHandle_t) new std::mutex)
+{}
+
+Mutex::Mutex(Mutex&& rhs) :
+    mMutexHandle(rhs.mMutexHandle)
+{
+    rhs.mMutexHandle = nullptr;
+}
+
+Mutex& Mutex::operator=(Mutex&& rhs)
+{
+    mMutexHandle = rhs.mMutexHandle;
+    rhs.mMutexHandle = nullptr;
+    return *this;
+}
+
+Mutex::~Mutex(void)
+{
+    delete (int*)mMutexHandle;
+    mMutexHandle = nullptr;
+}
+
+bool Mutex::take(uint32_t ticksToWait) const
+{
+    if (*this) {
+        std::mutex* m = reinterpret_cast<std::mutex*>(mMutexHandle);
+        m->lock();
+        return true;
+    }
+
+    return false;
+}
+
+bool Mutex::give(void) const
+{
+    if (*this) {
+        std::mutex* m = reinterpret_cast<std::mutex*>(mMutexHandle);
+        m->unlock();
+        return true;
+    }
+    return false;
+}
+
+Mutex::operator bool() const
+{
+    return mMutexHandle != nullptr;
+}
+}

--- a/sources/os/OsTestMockup_ut.cpp
+++ b/sources/os/OsTestMockup_ut.cpp
@@ -1,0 +1,138 @@
+/// @file OsTestMockup_ut.cpp
+/// @brief Test cases for the os TestMockups on which other tests rely.
+/// @author Henning Mende (henning@my-urmo.com)
+/// @date   Nov 19, 2019
+/// @copyright UrmO GmbH
+///
+/// You need to be sure your testing tools work!
+///
+/// This program is free software: you can redistribute it and/or modify it under the terms
+/// of the GNU General Public License as published by the Free Software Foundation, either
+/// version 3 of the License, or (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+/// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+/// See the GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License along with this program.
+/// If not, see <https://www.gnu.org/licenses/>.
+#include "unittest.h"
+
+#include "os_Task.h"
+#include "Semaphore.h"
+#include "Mutex.h"
+#include "LockGuard.h"
+
+int ut_TestTaskMock(void)
+{
+    TestCaseBegin();
+
+    constexpr int want = 100;
+    int have = 0;
+
+    {
+        os::Task sut("name", 1024, os::Task::Priority::MEDIUM, [&have](const bool& join){
+                     for (unsigned int i = 0; i < 100; i++) {
+                         os::ThisTask::yield();
+                         have++;
+                     }
+                     os::ThisTask::sleep(std::chrono::milliseconds(5));
+            });
+
+        CHECK(want != have);
+    }
+
+    CHECK(want == have);
+
+    TestCaseEnd();
+}
+
+int ut_TestMutexMock(void)
+{
+    TestCaseBegin();
+    constexpr unsigned int compareValue = 1000, want = compareValue * 2;
+    unsigned int have = 0;
+    const os::Mutex mutex;
+
+    std::function<void(const bool&)> funcWithout([&](const bool& join) {
+                                                 for (unsigned int i = 0; i < compareValue; i++) {
+                                                     const unsigned int tmp = have;
+                                                     os::ThisTask::yield();
+                                                     have = tmp + 1;
+                                                     os::ThisTask::yield();
+                                                 }
+        });
+
+    std::function<void(const bool&)> funcWith([&](const bool& join) {
+                                              for (unsigned int i = 0; i < compareValue; i++) {
+                                                  mutex.take();
+                                                  const unsigned int tmp = have;
+                                                  os::ThisTask::yield();
+                                                  have = tmp + 1;
+                                                  mutex.give();
+                                                  os::ThisTask::yield();
+                                              }
+        });
+
+    {
+        os::Task t1("t1", 1, os::Task::Priority::MEDIUM, funcWithout);
+        os::Task t2("t2", 2, os::Task::Priority::MEDIUM, funcWithout);
+    }
+
+    CHECK(want != have);
+
+    {
+        have = 0;
+        os::Task t1("t1", 1, os::Task::Priority::MEDIUM, funcWith);
+        os::Task t2("t2", 2, os::Task::Priority::MEDIUM, funcWith);
+    }
+
+    CHECK(want == have);
+
+    TestCaseEnd();
+}
+
+int ut_TestSemaphoreMock(void)
+{
+    TestCaseBegin();
+
+    constexpr unsigned int compareValue = 1000, want = compareValue + 1;
+    unsigned int have = 0;
+    bool done = false;
+    const os::Semaphore semaphore;
+
+    std::function<void(const bool&)> supplier([&](const bool& join) {
+                                              for (unsigned int i = 0; i < compareValue; i++) {
+                                                  semaphore.give();
+                                                  os::ThisTask::yield();
+                                                  os::ThisTask::sleep(std::chrono::milliseconds(1));
+                                              }
+                                              done = true;
+                                              semaphore.give();
+        });
+
+    std::function<void(const bool&)> consumer([&](const bool& join) {
+                                              while (!done) {
+                                                  semaphore.take();
+                                                  have++;
+                                              }
+        });
+
+    {
+        os::Task consumerTask("t1", 1, os::Task::Priority::MEDIUM, consumer);
+        os::Task supplierTask("t2", 2, os::Task::Priority::MEDIUM, supplier);
+    }
+
+    CHECK(want == have);
+
+    TestCaseEnd();
+}
+
+int main(int argc, char** argv)
+{
+    UnitTestMainBegin();
+    RunTest(true, ut_TestTaskMock);
+    RunTest(true, ut_TestMutexMock);
+    RunTest(true, ut_TestSemaphoreMock);
+    UnitTestMainEnd();
+}

--- a/sources/os/OsTestMockup_ut.cpp
+++ b/sources/os/OsTestMockup_ut.cpp
@@ -23,6 +23,8 @@
 #include "Mutex.h"
 #include "LockGuard.h"
 
+bool executeMockupTasks = true;
+
 int ut_TestTaskMock(void)
 {
     TestCaseBegin();
@@ -40,6 +42,25 @@ int ut_TestTaskMock(void)
             });
 
         CHECK(want != have);
+    }
+
+    CHECK(want == have);
+
+    TestCaseEnd();
+}
+
+int ut_TestExecutionSwitch(void)
+{
+    TestCaseBegin();
+
+    constexpr int want = 13;
+    int have = want;
+    executeMockupTasks = false;
+
+    {
+        os::Task sut("name", 1024, os::Task::Priority::MEDIUM, [&have](const bool& join){
+                     have = 7;
+            });
     }
 
     CHECK(want == have);

--- a/sources/os/OsTestMockup_ut.cpp
+++ b/sources/os/OsTestMockup_ut.cpp
@@ -237,6 +237,30 @@ int ut_TaskInterruptableMockDetach(void)
     TestCaseEnd();
 }
 
+int ut_SemaphoreMockTimeout(void)
+{
+    TestCaseBegin();
+
+    const os::Semaphore semaphore;
+    constexpr std::chrono::milliseconds waitTimeMS(200);
+    bool have = false;
+
+    os::Task testTask("test", 42,
+                      os::Task::Priority::MEDIUM,
+                      [&](const bool& join){
+                      os::ThisTask::sleep(std::chrono::milliseconds(waitTimeMS * 2));
+                      semaphore.give();
+        });
+
+    have = semaphore.take(waitTimeMS);
+    CHECK(have == false);
+    os::ThisTask::sleep(std::chrono::milliseconds(10));
+    have = semaphore.take(waitTimeMS);
+    CHECK(have == true);
+
+    TestCaseEnd();
+}
+
 int main(int argc, char** argv)
 {
     UnitTestMainBegin();
@@ -247,6 +271,7 @@ int main(int argc, char** argv)
     RunTest(true, ut_TaskInterruptableMockBasicBehavior);
     RunTest(true, ut_TaskInterruptableMockStartStop);
     RunTest(true, ut_TaskInterruptableMockDetach);
+    RunTest(true, ut_SemaphoreMockTimeout);
 
     UnitTestMainEnd();
 }

--- a/sources/os/SemaphoreTestMockup.cpp
+++ b/sources/os/SemaphoreTestMockup.cpp
@@ -1,0 +1,76 @@
+/// @file SemaphoreTestMockup.cpp
+/// @brief Mockup for software tests of classes dependent on os::Semaphore.
+/// @author Henning Mende (henning@my-urmo.com)
+/// @date   Nov 19, 2019
+/// @copyright UrmO GmbH
+///
+/// This program is free software: you can redistribute it and/or modify it under the terms
+/// of the GNU General Public License as published by the Free Software Foundation, either
+/// version 3 of the License, or (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+/// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+/// See the GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License along with this program.
+/// If not, see <https://www.gnu.org/licenses/>.
+#include "Semaphore.h"
+
+#include <mutex>
+
+namespace os
+{
+Semaphore::Semaphore(void) :
+    mSemaphoreHandle((SemaphoreHandle_t) new std::mutex)
+{
+    std::mutex* m = reinterpret_cast<std::mutex*>(mSemaphoreHandle);
+    m->lock();
+}
+
+Semaphore::Semaphore(Semaphore&& rhs) :
+    mSemaphoreHandle(rhs.mSemaphoreHandle)
+{
+    rhs.mSemaphoreHandle = nullptr;
+    std::mutex* m = reinterpret_cast<std::mutex*>(mSemaphoreHandle);
+    m->lock();
+}
+
+Semaphore& Semaphore::operator=(Semaphore&& rhs)
+{
+    mSemaphoreHandle = rhs.mSemaphoreHandle;
+    rhs.mSemaphoreHandle = nullptr;
+    return *this;
+}
+
+Semaphore::~Semaphore(void)
+{
+    delete (int*)mSemaphoreHandle;
+    mSemaphoreHandle = nullptr;
+}
+
+bool Semaphore::take(uint32_t ticksToWait) const
+{
+    if (*this) {
+        std::mutex* m = reinterpret_cast<std::mutex*>(mSemaphoreHandle);
+        m->lock();
+        return true;
+    }
+
+    return false;
+}
+
+bool Semaphore::give(void) const
+{
+    if (*this) {
+        std::mutex* m = reinterpret_cast<std::mutex*>(mSemaphoreHandle);
+        m->unlock();
+        return true;
+    }
+    return false;
+}
+
+Semaphore::operator bool() const
+{
+    return mSemaphoreHandle != nullptr;
+}
+}

--- a/sources/os/TaskInterruptableTestMockup.cpp
+++ b/sources/os/TaskInterruptableTestMockup.cpp
@@ -1,0 +1,73 @@
+/// @file TaskInterruptableTestMockup.cpp
+/// @brief TODO brief description.
+/// @author Henning Mende (henning@my-urmo.com)
+/// @date   Nov 26, 2019
+/// @copyright UrmO GmbH
+///
+/// Unauthorized copying of this file, via any medium is strictly prohibited.
+/// Proprietary and confidential.
+#include "TaskInterruptable.h"
+#include "Semaphore.h"
+#include <thread>
+
+/// @brief Set this true in tests to execute the tasks.
+/// Otherwise the os::Task interface is linked to empty function bodies.
+extern bool executeMockupTasks;
+
+namespace os
+{
+TaskInterruptable::TaskInterruptable(char const* const                      name,
+                                     const uint16_t                         stackSize,
+                                     const os::Task::Priority               priority,
+                                     const std::function<void(const bool&)> function) :
+    Task(name, stackSize, priority, function),
+    mJoinFlag(false)
+{
+    if (executeMockupTasks) {
+        mJoinSemaphore = reinterpret_cast<xSemaphoreHandle>(new os::Semaphore());
+    }
+}
+
+TaskInterruptable::~TaskInterruptable(void)
+{
+    if ((mHandle != nullptr) && executeMockupTasks) {
+        join();
+
+        os::Semaphore* pSemaphore = reinterpret_cast<os::Semaphore*>(mJoinSemaphore);
+        delete pSemaphore;
+    }
+}
+
+void TaskInterruptable::taskFunction(void)
+{
+    mTaskFunction(mJoinFlag);
+    std::thread* pTmp = reinterpret_cast<std::thread*>(mHandle);
+    mHandle = nullptr;
+    pTmp->detach();
+    delete pTmp;
+    reinterpret_cast<os::Semaphore*>(mJoinSemaphore)->give();
+}
+
+void TaskInterruptable::start(void)
+{
+    mJoinFlag = false;
+    if ((mHandle == nullptr) && executeMockupTasks) {
+        mHandle = reinterpret_cast<xTaskHandle>(new std::thread([this] {
+                taskFunction();
+            }));
+    }
+}
+
+void TaskInterruptable::join(void)
+{
+    mJoinFlag = true;
+    if ((mHandle != nullptr) && executeMockupTasks) {
+        reinterpret_cast<os::Semaphore*>(mJoinSemaphore)->take();
+    }
+}
+
+void TaskInterruptable::detach(void)
+{
+    this->mJoinFlag = true;
+}
+}  // namespace os

--- a/sources/os/TaskTestMockup.cpp
+++ b/sources/os/TaskTestMockup.cpp
@@ -1,0 +1,53 @@
+/// @file TaskTestMockup.cpp
+/// @brief Alternate implementation for os::Task, to map tasks to c++ std::threads.
+/// @author Henning Mende (henning@my-urmo.com)
+/// @date   Nov 19, 2019
+/// @copyright UrmO GmbH
+///
+/// This implementation is intended for software tests of classes that depend on os::Thread.
+///
+/// This program is free software: you can redistribute it and/or modify it under the terms
+/// of the GNU General Public License as published by the Free Software Foundation, either
+/// version 3 of the License, or (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+/// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+/// See the GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License along with this program.
+/// If not, see <https://www.gnu.org/licenses/>.
+
+#include "os_Task.h"
+#include "thread"
+
+os::Task::Task(char const* name, unsigned short stack, os::Task::Priority prio,
+               std::function<void(bool const&)> func) : mHandle(nullptr), mTaskFunction(func)
+{
+    mHandle = reinterpret_cast<xTaskHandle>(new std::thread([this] {
+        taskFunction();
+    }));
+}
+
+os::Task::~Task(void)
+{
+    if (mHandle != nullptr) {
+        std::thread* pTmp = reinterpret_cast<std::thread*>(mHandle);
+        pTmp->join();
+        delete pTmp;
+    }
+}
+
+void os::Task::taskFunction(void)
+{
+    mTaskFunction(false);
+}
+
+void os::ThisTask::sleep(const std::chrono::milliseconds ms)
+{
+    std::this_thread::sleep_for(ms);
+}
+
+void os::ThisTask::yield(void)
+{
+    std::this_thread::yield();
+}

--- a/sources/os/TaskTestMockup.cpp
+++ b/sources/os/TaskTestMockup.cpp
@@ -4,7 +4,12 @@
 /// @date   Nov 19, 2019
 /// @copyright UrmO GmbH
 ///
+/// The `extern` variable @ref executeMockupTasks need to be defined in your main test
+/// application.
+///
 /// This implementation is intended for software tests of classes that depend on os::Thread.
+/// If you decide, that you don't want to run the task (e.g. for testing endless tasks) simply
+/// set the @ref executeMockupTasks in your tests to false.
 ///
 /// This program is free software: you can redistribute it and/or modify it under the terms
 /// of the GNU General Public License as published by the Free Software Foundation, either
@@ -20,12 +25,18 @@
 #include "os_Task.h"
 #include "thread"
 
+/// @brief Set this true in tests to execute the tasks.
+/// Otherwise the os::Task interface is linked to empty function bodies.
+extern bool executeMockupTasks;
+
 os::Task::Task(char const* name, unsigned short stack, os::Task::Priority prio,
                std::function<void(bool const&)> func) : mHandle(nullptr), mTaskFunction(func)
 {
-    mHandle = reinterpret_cast<xTaskHandle>(new std::thread([this] {
-        taskFunction();
-    }));
+    if (executeMockupTasks) {
+        mHandle = reinterpret_cast<xTaskHandle>(new std::thread([this] {
+            taskFunction();
+        }));
+    }
 }
 
 os::Task::~Task(void)

--- a/sources/utility/returnTypeDeduction.h
+++ b/sources/utility/returnTypeDeduction.h
@@ -1,0 +1,97 @@
+/// @file returnTypeDeduction.h
+/// @brief Helper functions to deduct the return type at compile time.
+/// @author Henning Mende (henning@my-urmo.com)
+/// @date   Sep 12, 2019
+/// @copyright UrmO GmbH
+///
+/// This program is free software: you can redistribute it and/or modify it under the terms
+/// of the GNU General Public License as published by the Free Software Foundation, either
+/// version 3 of the License, or (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+/// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+/// See the GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License along with this program.
+/// If not, see <https://www.gnu.org/licenses/>.
+///
+#ifndef SOURCES_UTILITY_RETURNTYPEDEDUCTION_H_
+#define SOURCES_UTILITY_RETURNTYPEDEDUCTION_H_
+
+namespace utility
+{
+/// @brief Helper to determine the return type of a function.
+///
+/// This can be used to determine the return type of overloaded or templated functions at
+/// compile time, even if the functions are not `constexpr`.
+///
+/// Usage:
+/// @code
+/// int foo(float a);
+/// float foo(int a);
+/// decltype(getReturnType<float>(foo)) b = 3;
+/// @endcode
+///
+/// In this example b is int.
+///
+/// @tparam R Return type (evaluated automatically).
+/// @tparam A Argument types for the target function (for overloaded functions).
+/// @param * Function with @a A parameters.
+/// @return Type of the return value of @a *.
+template<typename R, typename ... A>
+R getReturnType(R (*)(A ...));
+
+/// @brief Helper to determine the return type of a method.
+///
+/// This can be used to determine the return type of overloaded or templated methods at compile
+/// time, even if the methods are not `constexpr`.
+///
+/// Usage:
+/// @code
+/// struct Foo {
+///     int foo(float a);
+///     float foo(int a);
+///    } fooInstance;
+///    decltype(utility::getReturnType<float>(& Foo::foo)) b = 3;
+///    decltype(utility::getReturnType<float>(& decltype(fooInstance)::foo)) c = 3;
+/// @endcode
+///
+/// In this example b and c are int.
+///
+/// @tparam M Matching version of the overloaded method (evaluated by template parameter @a A).
+/// @tparam C Class name (evaluated by argument).
+/// @tparam R Return type (evaluated automatically).
+/// @tparam A Argument types for the target method (for overloaded methods).
+/// @param * Method with @a A parameters.
+/// @return Type of the return value of @a *.
+template<typename M, typename C, typename R, typename ... A>
+R getReturnType(R (C::*)(M, A ...));
+
+/// @brief Helper to determine the return type of a const method.
+///
+/// This can be used to determine the return type of overloaded or templated methods at compile
+/// time, even if the methods are not `constexpr`.
+///
+/// Usage:
+/// @code
+/// struct Foo {
+///     int foo(float a) const;
+///     float foo(int a) const;
+///    } fooInstance;
+///    decltype(utility::getReturnType<float>(& Foo::foo)) b = 3;
+///    decltype(utility::getReturnType<float>(& decltype(fooInstance)::foo)) c = 3;
+/// @endcode
+///
+/// In this example b and c are int.
+///
+/// @tparam V Matching version of the overloaded method (evaluated by template parameter @a A).
+/// @tparam C Class name (evaluated by argument).
+/// @tparam R Return type (evaluated automatically).
+/// @tparam A Argument types for the target method (for overloaded methods).
+/// @param * Method with A parameters.
+/// @return Type of the return value of @a *.
+template<typename V, typename C, typename R, typename ... A>
+R getReturnType(R (C::*)(V, A ...) const);
+} // namespace utility
+
+#endif // SOURCES_UTILITY_RETURNTYPEDEDUCTION_H_


### PR DESCRIPTION
Some test mocks for os layer classes. 
So there is no need to mock these classes each time you want to test an application. Just link against these implementations. They map the thread, mutex and semaphore FreeRTOS functionality onto the std::thread library. Which maps them to posix (at least on linux/unix systems). 

In the project_stm32f4_discovery is an example test using and testing these mocks... because you need to know that your testing tools and mocks really work!