### PR TITLE
clear interrupts after disabling the dma, to avoid immediatly firing …

### DIFF
--- a/sources/hal_stm32f4xx/Dma.cpp
+++ b/sources/hal_stm32f4xx/Dma.cpp
@@ -207,6 +207,7 @@ void Dma::enable(void) const
 void Dma::disable(void) const
 {
     DMA_Cmd(reinterpret_cast<DMA_Stream_TypeDef*>(mPeripherie), DISABLE);
+    ClearInterruptFlag(this);
 }
 
 bool Dma::registerInterruptSemaphore(os::Semaphore* const semaphore, const Dma::InterruptSource source) const


### PR DESCRIPTION
…interrupts after reenable

See the note in reference manual chapter 10.3.14 DMA transfer suspension

Without this line a reoccurring NO_COMMUNICATION_ERROR may be generated by the app::Communication.