### PR TITLE
execute correct function before test

### DIFF
--- a/sources/com/DataTransferObject_ut.cpp
+++ b/sources/com/DataTransferObject_ut.cpp
@@ -197,7 +197,7 @@ int ut_tupleValid(void)
     uint8_t c = 3;
 
     com::DataTransferObject<uint32_t, uint16_t, uint8_t> dto(a, b, c);
-    dto.updateTuple();
+    dto.prepareForTx();
     CHECK(dto.isValid() == true);
     TestCaseEnd();
 }


### PR DESCRIPTION
Actually I have no idea why the tests were working before. But if you add further unit test or other functions before executing `ut_tupleValid` you can alter the stack content and the `dto.isValid()` method fails. Before this change the CRC of `mTransferData` was always (!but accidentally!) initialized to 0, which was also `g_crc` as compare value. I just noticed this randomly.