### PR TITLE
Uncrustify textfiles

### DIFF
--- a/project_stm32f4_discovery/Makefile.in
+++ b/project_stm32f4_discovery/Makefile.in
@@ -20,7 +20,7 @@
 
 #******************************************************************************
 #
-# Makefile - Rules for building the WyLight bootloader.
+# Makefile - Rules for building the STM32F4 Discovery board demo
 #
 #
 #*****************************************************************************
@@ -81,9 +81,11 @@ filelist:
 	@$(foreach END, ${ENDINGS}, $(foreach DIR, ${CODE_DIRS}, find ./$(DIR) -name "*.$(END)" >> $@.txt;))
 	@echo "Created $@.txt"
 
+REPLACE_CMD=sed -i -e 's/\s\+$$//g'
 uncrustify: filelist
 	${UNCRUSTIFY} -F filelist.txt --no-backup -c ../utilities/uncrustify.cfg
-
+	# clean trailing white space in text and markdown files
+	@$(foreach END, md txt, $(foreach DIR, ${CODE_DIRS}, find ./$(DIR) -name "*.$(END)" -exec ${REPLACE_CMD} '{}' \;;))
 
 # The rule to clean out all the build products.
 clean:

--- a/project_stm32f4_discovery/README.md
+++ b/project_stm32f4_discovery/README.md
@@ -1,7 +1,7 @@
 # STM32F407-Discovery board demo project
 
 This is a simple example project for the STM32F407-Discovery Board to show the usage
-of the STM32F4 hardware abstraction layer of the `STM_HAL` project. 
+of the STM32F4 hardware abstraction layer of the `STM_HAL` project.
 
 ## Functionality
 
@@ -14,7 +14,7 @@ The project consists of four tasks/apps:
 2. TestRtc:
 
    This Tasks initializes the real time clock (RTC) to 12 o'clock on the 14th of
-   September 2015 and then prints once a second the current RTC reading to the 
+   September 2015 and then prints once a second the current RTC reading to the
    debug interface.
 
 3. uart demo (anonymous, created in main procedure):
@@ -24,22 +24,22 @@ The project consists of four tasks/apps:
 
 4. adc demo (anonymous, created in main procedure):
 
-   Every second this tasks prints the current  reading of the analog to digital 
+   Every second this tasks prints the current  reading of the analog to digital
    converter (ADC) on pin C1 to the debug interface.
 
-By pressing the "User Button" the direction of the LedBlinker animation can be 
+By pressing the "User Button" the direction of the LedBlinker animation can be
 inversed.
 
-All of these Tasks can be monitored by SEGGER SystemView. The interrupt tracing is 
+All of these Tasks can be monitored by SEGGER SystemView. The interrupt tracing is
 enabled as well. It is set by the startup script.
 
 ## Pin mapping
 
-- Debug interface on 
+- Debug interface on
   - Pin A8 Tx
   - Pin A9 Rx
 
-- Communication interface on 
+- Communication interface on
   - Pin C10 Tx
   - Pin C11 Rx
 

--- a/utilities/pre-commit.settings.in
+++ b/utilities/pre-commit.settings.in
@@ -23,6 +23,7 @@ PARSE_EXTS=true
 
 # file types to parse. Only effective when PARSE_EXTS is true.
 # FILE_EXTS=".c .h .cpp .hpp"
-FILE_EXTS=".c .h .cpp .hpp"
+TEXT_FILE_EXTS=" .txt .md"
+FILE_EXTS=".c .h .cpp .hpp"${TEXT_FILE_EXTS}
 
 ##################################################################

--- a/utilities/pre-commit.uncrustify
+++ b/utilities/pre-commit.uncrustify
@@ -37,6 +37,17 @@ matches_extension() {
     return 1
 }
 
+# check whether the given file matches any of the set text file extensions
+is_text_file() {
+    local filename="$(basename -- "$1")"
+    local extension=".${filename##*.}"
+    local ext
+
+    for ext in $TEXT_FILE_EXTS; do [ "$ext" = "$extension" ] && return 0; done
+
+    return 1
+}
+
 # necessary check for initial commit
 if $GIT rev-parse --verify HEAD >/dev/null 2>&1 ; then
     against=HEAD
@@ -76,6 +87,7 @@ do
     # ignore file if we do check for file extensions and the file
     # does not match any of the extensions specified in $FILE_EXTS
     if $PARSE_EXTS && ! matches_extension "$file"; then
+        echo $file does not match extenstion $FILE_EXTS
         continue;
     fi
 
@@ -101,6 +113,20 @@ do
     #     - '|': used as sed split char instead of '/'
     # printf %s particularly important if the filename contains the % character
     file_escaped_target=$(printf "%s" "$file" | sed -e 's/[\"]/\\&/g' -e 's/[\&|]/\\&/g')
+
+    # remove trailing white spaces from text files, and continue with next file.
+    if $PARSE_EXTS && is_text_file "$file"; then
+        # remove trailing white space characters and create a patch
+        # (for documentation of the patch creation read block comment below)
+        #echo process text file $file
+		sed -e 's/\s\+$//g' $file | \
+            diff -u -- "$file" - | \
+            sed -e "1s|--- $file_escaped_source|--- \"a/$file_escaped_target\"|" -e "2s|+++ -|+++ \"b/$file_escaped_target\"|" >> "$patch"
+
+        # Don't pass text files to uncrustify
+        continue;
+    fi
+    
 
     # uncrustify our sourcefile, create a patch with diff and append it to our $patch
     # The sed call is necessary to transform the patch from


### PR DESCRIPTION
I added a little [sed](http://sed.sf.net) command to the uncrustify rule, which removes trailing whitespace characters in text and markdown files (other file types could be added, too). I've done this for the the Makefile.in in project_stm32f4_discovery. If you think, this is useful, you can use it in other projects as well. Additionally I added this to the pre-commit hook. There it doesn't remove the white space characters in place, but creates a patch with the proposed changes. 