### PR TITLE
Bugfix: faulty check for plausible FF

### DIFF
--- a/sources/app/IsoTp.cpp
+++ b/sources/app/IsoTp.cpp
@@ -143,7 +143,7 @@ size_t ISOTP::receive_SF(const std::string_view message, char* buffer, const siz
 
 size_t ISOTP::receive_FF(const std::string_view message, char* buffer, const size_t length)
 {
-    mRxMsgLength = (message[0] & 0x0f) | (message[1]);
+    mRxMsgLength = ((message[0] & 0x0f) << 8) | (message[1]);
 
     if (mRxMsgLength <= MAX_SINGLE_FRAME_PAYLOAD) {
         Trace(ZONE_INFO, "Message is to short for a first frame.\r\n");


### PR DESCRIPTION
For IsoTp messages with 256 Bytes and a few bytes longer the check for (mRxMsgLength <= MAX_SINGLE_FRAME_PAYLOAD) evaluated as true, hence being declared as too short.
Reason: MSB of the length was treated as LSB for the bitwise or operation