### PR TITLE
reintroduce library location to stm32f4_discovery demo makefile

### DIFF
--- a/project_stm32f4_discovery/Makefile.prj
+++ b/project_stm32f4_discovery/Makefile.prj
@@ -45,7 +45,7 @@ VPATH+=${ROOT}/libraries/CMSIS/Source
 VPATH+=${ROOT}/libraries/CMSIS/Device/ST/STM32F4xx/Source
 VPATH+=${ROOT}/libraries/CMSIS/Device/ST/STM32F4xx/Source/Templates
 VPATH+=${ROOT}/libraries/STM32F4xx_StdPeriph_Driver/src
-VPATH+=${ROOT}/libraries/Filters-master
+VPATH+=${ROOT}/libraries/STM32F4xx_EEPROM_EMULATION
 
 ifneq (,$(findstring DSYSVIEW, $(DEFINES)))
 VPATH+=${SEGGER_SOURCE_DIR}/SEGGER


### PR DESCRIPTION
I'm sorry, after the rebasing my last pull request into master one line for the library location was lost in the Makefile. This hotfix reintroduces it, so the stm32f4 discovery demo project will compile again.